### PR TITLE
Improve token-metadata-creator error messages

### DIFF
--- a/token-metadata-creator/app/Config.hs
+++ b/token-metadata-creator/app/Config.hs
@@ -219,8 +219,11 @@ wellKnownOption =
     -- To handle the cases of both JSON strings and any other JSON
     -- value, we first try to parse it as a raw value, then if that
     -- fails with an error like "not a valid json value", then we
-    -- treat the input as a string and try to parse that.
+    -- treat the input as a string and try to parse that. This at the
+    -- very least gives us a better error message.
     isPotentiallyString :: forall x. Either String x -> Bool
     isPotentiallyString (Left err) | "not a valid json value" `isSuffixOf` err = True
+    isPotentiallyString (Left err) | "endOfInput" `isSuffixOf` err             = True
+    isPotentiallyString (Left err) | "takeWhile1" `isSuffixOf` err             = True
     isPotentiallyString (Left _)                                               = False
     isPotentiallyString (Right _)                                              = False

--- a/token-metadata-creator/app/Config.hs
+++ b/token-metadata-creator/app/Config.hs
@@ -210,7 +210,7 @@ wellKnownOption =
     asJSONValue = (Aeson.parseEither parseWellKnown =<<) . Aeson.eitherDecodeStrict' . BC8.pack
     -- Presume we got a string (i.e. "3" or "potato").
     asJSONString :: String -> Either String p
-    asJSONString = Aeson.parseEither parseWellKnown . Aeson.toJSON
+    asJSONString = Aeson.parseEither parseWellKnown . Aeson.String . T.pack
 
     -- A program called with the arguments "--arg hello" will pass the
     -- value "hello" to the JSON parser. "hello" is not a valid JSON

--- a/token-metadata-creator/app/Config.hs
+++ b/token-metadata-creator/app/Config.hs
@@ -225,5 +225,6 @@ wellKnownOption =
     isPotentiallyString (Left err) | "not a valid json value" `isSuffixOf` err = True
     isPotentiallyString (Left err) | "endOfInput" `isSuffixOf` err             = True
     isPotentiallyString (Left err) | "takeWhile1" `isSuffixOf` err             = True
+    isPotentiallyString (Left err) | "string" `isSuffixOf` err                 = True
     isPotentiallyString (Left _)                                               = False
     isPotentiallyString (Right _)                                              = False

--- a/token-metadata-creator/app/Config.hs
+++ b/token-metadata-creator/app/Config.hs
@@ -84,7 +84,7 @@ data Arguments
 
 argumentParser :: Maybe Subject -> OA.Parser Arguments
 argumentParser defaultSubject =
-  OA.hsubparser 
+  OA.hsubparser
     ( OA.command "entry" (OA.info (ArgumentsEntryUpdate <$> entryUpdateArgumentParser defaultSubject) mempty)
    <> OA.command "validate" (OA.info (ArgumentsValidate <$> pFileA <*> pFileB <*> pLogSeverity) mempty)
     )
@@ -154,7 +154,7 @@ entryUpdateArgumentParser defaultSubject = EntryUpdateArguments
         <*> pure Nothing -- logo
         <*> optional (emptyAttested <$> wellKnownOption (OA.long "url" <> OA.short 'h' <> OA.metavar "URL"))
         <*> optional (emptyAttested <$> wellKnownOption (OA.long "ticker" <> OA.short 't' <> OA.metavar "TICKER"))
-        <*> optional (emptyAttested <$> OA.option (OA.eitherReader ((Aeson.parseEither parseWellKnown =<<) . Aeson.eitherDecodeStrict . BC8.pack)) (OA.long "decimals" <>  OA.metavar "DECIMALS"))
+        <*> optional (emptyAttested <$> wellKnownOption (OA.long "decimals" <>  OA.metavar "DECIMALS"))
 
 pLogSeverity :: OA.Parser Colog.Severity
 pLogSeverity = pDebug <|> pInfo <|> pWarning <|> pError <|> pure I
@@ -196,8 +196,31 @@ wellKnownOption
     => OA.Mod OA.OptionFields p
     -> OA.Parser p
 wellKnownOption =
-    OA.option wellKnownReader
+  OA.option (OA.eitherReader (\arg ->
+                               let
+                                 r1 = asJSONValue arg
+                               in
+                                 if isPotentiallyString r1
+                                 then asJSONString arg
+                                 else r1
+                             ))
   where
-    wellKnownReader :: OA.ReadM p
-    wellKnownReader = OA.eitherReader $
-        Aeson.parseEither parseWellKnown . Aeson.toJSON
+    -- Presume we got a value (i.e. 3 or []).
+    asJSONValue :: String -> Either String p
+    asJSONValue = (Aeson.parseEither parseWellKnown =<<) . Aeson.eitherDecodeStrict' . BC8.pack
+    -- Presume we got a string (i.e. "3" or "potato").
+    asJSONString :: String -> Either String p
+    asJSONString = Aeson.parseEither parseWellKnown . Aeson.toJSON
+
+    -- A program called with the arguments "--arg hello" will pass the
+    -- value "hello" to the JSON parser. "hello" is not a valid JSON
+    -- value, you might expect it to be treated as a string, but the
+    -- correct way to pass a string to a JSON parser is "\"hello\"".
+    -- To handle the cases of both JSON strings and any other JSON
+    -- value, we first try to parse it as a raw value, then if that
+    -- fails with an error like "not a valid json value", then we
+    -- treat the input as a string and try to parse that.
+    isPotentiallyString :: forall x. Either String x -> Bool
+    isPotentiallyString (Left err) | "not a valid json value" `isSuffixOf` err = True
+    isPotentiallyString (Left _)                                               = False
+    isPotentiallyString (Right _)                                              = False

--- a/token-metadata-creator/app/token-metadata-creator.hs
+++ b/token-metadata-creator/app/token-metadata-creator.hs
@@ -82,10 +82,10 @@ import Config
     , canonicalFilename
     , draftFilename
     )
-import System.IO
-    ( hSetEncoding, mkTextEncoding)
 import GHC.IO.Encoding
     ( setFileSystemEncoding )
+import System.IO
+    ( hSetEncoding, mkTextEncoding )
 import System.IO.CodePage
     ( withCP65001 )
 

--- a/token-metadata-creator/test/index.spec.js
+++ b/token-metadata-creator/test/index.spec.js
@@ -8,6 +8,7 @@ const { assert } = require('chai');
 
 let cli, getDraft, withDraft, getFinal, writeTmpFile;
 
+process.env['LANG'] = 'en_US.UTF-8';
 
 const alice = "19309eb9c066253cede617dc635223ace320ae0bbdd5bd1968439cd0";
 const bob = "04c24626761279476a9da9b9d851328cab93d92e7a8790852e42ff894b746f725a436f696e";
@@ -136,6 +137,13 @@ describe("token-metadata-creator", () => {
       assert.isNotNull(getDraft(alice).name);
       cli(alice, "--init");
       assert.isNull(getDraft(alice).name);
+    });
+
+    it("Always handles UTF-8", () => {
+      process.env["LANG"] = "C";
+      cli(alice, "--name", "☃");
+      process.env["LANG"] = "en_US.UTF-8";
+      assert.equal(getDraft(alice).name.value, "☃");
     });
 
     it("Decimals range = [0,255]", () => {

--- a/token-metadata-creator/token-metadata-creator.cabal
+++ b/token-metadata-creator/token-metadata-creator.cabal
@@ -58,6 +58,7 @@ executable token-metadata-creator
                      , base64-bytestring
                      , bytestring
                      , cardano-prelude
+                     , code-page
                      , token-metadata-creator
                      , safe-exceptions
                      , co-log


### PR DESCRIPTION
- As per https://github.com/input-output-hk/offchain-metadata-tools/pull/26, improve error messages when failing to parse a decimals value.
- For well-known properties, we may be wanted to parse a String or some other type. I've improved the error messages by first trying to parse as an arbitrary JSON value, and it that fails with some "not a valid json value"-style errors, try to parse as a string. 
- It's only a quick fix, but it does provide better results:
```
$ token-metadata-creator entry ... --decimals "potato"
- option --decimals: Error in $: Failed reading: not a valid json value
+ option --decimals: Error in $: parsing Int failed, expected Number, but encountered String

$ token-metadata-creator entry ... --decimals 0x
- option --decimals: Error in $: endOfInput
+ option --decimals: Error in $: parsing Int failed, expected Number, but encountered String


$ token-metadata-creator entry ... --decimals 0.x
- option --decimals: Error in $: Failed reading: takeWhile1
+ option --decimals: Error in $: parsing Int failed, expected Number, but encountered String
```