### PR TITLE
Fix metadata desynchronization

### DIFF
--- a/cabal-nix.project
+++ b/cabal-nix.project
@@ -5,5 +5,6 @@ packages:
   ./metadata-webhook
   ./metadata-validator-github
   ./token-metadata-creator
+  ./metadata-sync
 tests: True
 benchmarks: True

--- a/cabal.project
+++ b/cabal.project
@@ -7,6 +7,7 @@ packages:
   ./metadata-store-postgres
   ./metadata-validator-github
   ./token-metadata-creator
+  ./metadata-sync
 
 package metadata-lib
   tests: True
@@ -24,6 +25,9 @@ package metadata-validator-github
   tests: True
 
 package token-metadata-creator
+  tests: True
+
+package metadata-sync
   tests: True
 
 -- ---------------------------------------------------------

--- a/default.nix
+++ b/default.nix
@@ -92,6 +92,7 @@ let
     inherit (project.hsPkgs.metadata-server.identifier) version;
     inherit (project.hsPkgs.metadata-server.components.exes) metadata-server;
     inherit (project.hsPkgs.metadata-webhook.components.exes) metadata-webhook;
+    inherit (project.hsPkgs.metadata-sync.components.exes) metadata-sync;
     inherit (project.hsPkgs.metadata-validator-github.components.exes) metadata-validator-github;
     inherit (project.hsPkgs.token-metadata-creator.components.exes) token-metadata-creator;
     inherit (project) metadata-validator-github-tarball token-metadata-creator-tarball;

--- a/metadata-lib/src/Test/Cardano/Metadata/Generators.hs
+++ b/metadata-lib/src/Test/Cardano/Metadata/Generators.hs
@@ -246,12 +246,12 @@ validationMetadata' = do
   validationMetadataSignedWith skey subj
 
 propertyName :: MonadGen m => m PropertyName
-propertyName = PropertyName <$> Gen.text (Range.linear 1 64) Gen.unicodeAll
+propertyName = PropertyName <$> Gen.text (Range.linear 1 64) Gen.unicode
 
 propertyValue :: MonadGen m => m Aeson.Value
 propertyValue =
   Gen.recursive Gen.choice
-    [ Aeson.String <$> Gen.text (Range.linear 1 64) Gen.unicodeAll
+    [ Aeson.String <$> Gen.text (Range.linear 1 64) Gen.unicode
     , Aeson.Number <$> fromIntegral <$> Gen.word8 Range.constantBounded
     , Aeson.Bool <$> Gen.bool
     , pure $ Aeson.Null

--- a/metadata-sync/metadata-sync.cabal
+++ b/metadata-sync/metadata-sync.cabal
@@ -1,0 +1,140 @@
+cabal-version:       >=1.10
+name:                metadata-sync
+version:             0.1.0.0
+author:              Samuel Evans-Powell
+maintainer:          mail@sevanspowell.net
+build-type:          Simple
+extra-source-files:  CHANGELOG
+
+library
+  hs-source-dirs:      src
+
+  exposed-modules:     Cardano.Metadata.Sync
+                       Cardano.Metadata.Sync.Config
+
+  build-depends:       aeson
+                     , base
+                     , bytestring
+                     , casing
+                     , containers
+                     , directory
+                     , filepath
+                     , postgresql-simple
+                     , lens
+                     , lens-aeson
+                     , metadata-lib
+                     , monad-logger
+                     , mtl
+                     , optparse-applicative
+                     , persistent
+                     , persistent-postgresql
+                     , persistent-template
+                     , resource-pool
+                     , safe-exceptions
+                     , scientific
+                     , servant
+                     , servant-server
+                     , temporary
+                     , text
+                     , time
+                     , turtle
+                     , unordered-containers
+                     , wai
+                     , warp
+
+  ghc-options:          -Wall
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wincomplete-patterns
+                        -Wredundant-constraints
+                        -Wpartial-fields
+                        -Wcompat
+
+test-suite integration-tests 
+  hs-source-dirs:       test
+  main-is:              Main.hs
+  type:                 exitcode-stdio-1.0
+
+  build-depends:  base >=4.12 && <5
+                , HUnit
+                , QuickCheck
+                , aeson
+                , aeson-pretty
+                , base
+                , bytestring
+                , casing
+                , containers
+                , directory
+                , hedgehog
+                , hspec
+                , http-client
+                , lens
+                , lens-aeson
+                , metadata-lib
+                , metadata-sync
+                , monad-logger
+                , postgresql-simple
+                , mtl
+                , raw-strings-qq
+                , resource-pool
+                , safe-exceptions
+                , scientific
+                , servant
+                , servant-client
+                , servant-server
+                , smallcheck
+                , tagged
+                , tasty
+                , tasty-hedgehog
+                , tasty-hspec
+                , tasty-hunit
+                , tasty-quickcheck
+                , text
+                , unordered-containers
+                , wai
+                , warp
+
+  ghc-options:          -Wall
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wincomplete-patterns
+                        -Wredundant-constraints
+                        -Wpartial-fields
+                        -Wcompat
+
+executable metadata-sync
+  hs-source-dirs:      src
+  main-is:             Main.hs
+  build-depends:       base
+                     , aeson
+                     , bytestring
+                     , containers
+                     , directory
+                     , filepath
+                     , lens
+                     , metadata-lib
+                     , metadata-sync
+                     , monad-logger
+                     , mtl
+                     , optparse-applicative
+                     , persistent
+                     , postgresql-simple
+                     , resource-pool
+                     , safe-exceptions
+                     , scientific
+                     , servant
+                     , temporary
+                     , text
+                     , time
+                     , turtle
+                     , warp
+
+  ghc-options:          -Wall
+                        -Wcompat
+                        -fwarn-redundant-constraints
+                        -fwarn-incomplete-patterns
+                        -fwarn-unused-imports
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wno-unsafe
+                        -threaded

--- a/metadata-sync/src/Cardano/Metadata/Sync.hs
+++ b/metadata-sync/src/Cardano/Metadata/Sync.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Cardano.Metadata.Sync where
+
+import qualified Data.Aeson as Aeson
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Turtle.Prelude as Turtle
+import System.Directory (listDirectory)
+import System.FilePath.Posix (takeBaseName)
+import Data.String (fromString)
+import System.IO.Temp (withSystemTempDirectory)
+import Database.PostgreSQL.Simple (withTransaction, execute, executeMany, Connection)
+import Database.PostgreSQL.Simple.Types (Identifier(..), Only(..), In(..))
+import Data.Traversable (forM)
+import Data.Functor (void)
+
+import Cardano.Metadata.Sync.Config (withConnectionFromPool)
+import Cardano.Metadata.Types.Common (Subject(..))
+
+-- | View the current state of the registry (source-of-truth).
+view :: Text -> Text -> IO [(Subject, Aeson.Value)]
+view gitURL gitSubFolder = do
+  withSystemTempDirectory "metadata-sync" $ \dir -> do
+
+    gitURL `cloneTo` dir
+
+    let dataDir = dir <> "/" <> T.unpack gitSubFolder
+    ks <- listDirectory dataDir
+    flip foldMap ks $ \k -> do
+      mV <- Aeson.decodeFileStrict' (dataDir <> "/" <> k)
+      case mV of
+        Nothing -> pure []
+        Just v -> pure [(Subject $ T.pack $ takeBaseName k, v)]
+
+  where
+    emptyDirectory dir = Turtle.procs "rm" ["-r", T.pack dir <> "/*"] mempty
+    cloneTo gitUrl dir = Turtle.procs "git" ["clone", gitUrl, T.pack dir] mempty
+
+-- | Write out a new state to our local copy of the registry.
+write :: Connection -> Text -> [(Subject, Aeson.Value)] -> IO ()
+write conn tableName kvs =
+  withTransaction conn $ do
+    let table = Identifier tableName
+
+    void $ execute conn "TRUNCATE ?" (Only table)
+
+    let dat = fmap (\(Subject k, v) -> (k, v)) kvs
+
+    void $ executeMany conn ("INSERT INTO " <> fromString (T.unpack tableName) <> " VALUES (?,?)") dat

--- a/metadata-sync/src/Cardano/Metadata/Sync.hs
+++ b/metadata-sync/src/Cardano/Metadata/Sync.hs
@@ -3,20 +3,31 @@
 module Cardano.Metadata.Sync where
 
 import qualified Data.Aeson as Aeson
-import Data.Text (Text)
+import Data.Functor
+    ( void )
+import Data.String
+    ( fromString )
+import Data.Text
+    ( Text )
 import qualified Data.Text as T
+import Data.Traversable
+    ( forM )
+import Database.PostgreSQL.Simple
+    ( Connection, execute, executeMany, withTransaction )
+import Database.PostgreSQL.Simple.Types
+    ( Identifier (..), In (..), Only (..) )
+import System.Directory
+    ( listDirectory )
+import System.FilePath.Posix
+    ( takeBaseName )
+import System.IO.Temp
+    ( withSystemTempDirectory )
 import qualified Turtle.Prelude as Turtle
-import System.Directory (listDirectory)
-import System.FilePath.Posix (takeBaseName)
-import Data.String (fromString)
-import System.IO.Temp (withSystemTempDirectory)
-import Database.PostgreSQL.Simple (withTransaction, execute, executeMany, Connection)
-import Database.PostgreSQL.Simple.Types (Identifier(..), Only(..), In(..))
-import Data.Traversable (forM)
-import Data.Functor (void)
 
-import Cardano.Metadata.Sync.Config (withConnectionFromPool)
-import Cardano.Metadata.Types.Common (Subject(..))
+import Cardano.Metadata.Sync.Config
+    ( withConnectionFromPool )
+import Cardano.Metadata.Types.Common
+    ( Subject (..) )
 
 -- | View the current state of the registry (source-of-truth).
 view :: Text -> Text -> IO [(Subject, Aeson.Value)]

--- a/metadata-sync/src/Cardano/Metadata/Sync/Config.hs
+++ b/metadata-sync/src/Cardano/Metadata/Sync/Config.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Cardano.Metadata.Sync.Config where
+
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import Options.Applicative (Parser, ParserInfo)
+import qualified Options.Applicative as Opt
+import Options.Applicative (strOption, long, metavar, help, showDefault, value, option, auto, info, fullDesc, progDesc, header)
+import Data.Pool (Pool, createPool, destroyAllResources)
+import Database.PostgreSQL.Simple (Connection)
+import Data.Time.Clock (NominalDiffTime)
+import qualified Database.PostgreSQL.Simple as Sql
+import qualified Data.Pool as Pool
+import qualified Data.ByteString.Char8 as BC
+import Control.Exception (bracket)
+
+data Opts = Opts
+    { optDbName              :: Text
+    , optDbUser              :: Text
+    , optDbHost              :: FilePath
+    , optDbMetadataTableName :: Text
+    , optDbConnections       :: Int
+    , optGitURL              :: Text
+    , optGitSubFolder        :: Text
+    }
+    deriving (Eq, Show)
+
+parseOpts :: Parser Opts
+parseOpts = Opts
+  <$> strOption (long "db" <> metavar "DB_NAME" <> help "Name of the database to store and read metadata from")
+  <*> strOption (long "db-user" <> metavar "DB_USER" <> help "User to connect to metadata database with")
+  <*> strOption (long "db-host" <> metavar "DB_HOST" <> showDefault <> value "/run/postgresql" <> help "Host for the metadata database connection")
+  <*> strOption (long "db-table" <> metavar "DB_TABLE" <> showDefault <> value "metadata" <> help "Table in the database to store metadata")
+  <*> option auto (long "db-conns" <> metavar "INT" <> showDefault <> value 1 <> help "Number of connections to open to the database")
+  <*> strOption (long "git-url" <> metavar "GIT_URL" <> help "URL of the metadata registry git repository")
+  <*> strOption (long "git-metadata-folder" <> metavar "GIT_METADATA_FOLDER" <> help "Sub-folder of the git repository containing the metadata")
+
+opts :: ParserInfo Opts
+opts =
+  info
+    parseOpts
+    ( fullDesc
+    <> progDesc "Sync up a metadata database with a GitHub repository"
+    <> header "metadata-sync - a tool to keep the metadata storage layer and the GitHub repository in sync"
+    )
+
+pgConnectionString :: Opts -> BC.ByteString
+pgConnectionString (Opts { optDbName = dbName, optDbUser = dbUser, optDbHost = dbHost }) =
+  TE.encodeUtf8 $ "host=" <> T.pack dbHost <> " dbname=" <> dbName <> " user=" <> dbUser
+
+mkConnectionPool
+  :: BC.ByteString
+  -- ^ Libpq connection string
+  -> Int
+  -- ^ Maximum number of postgresql connections to allow
+  -> IO (Pool Connection)
+mkConnectionPool connectionStr numConns =
+  createPool
+    (Sql.connectPostgreSQL connectionStr)
+    Sql.close
+    1                       -- Number of sub-pools
+    (10 :: NominalDiffTime) -- Amount of time for which an unused connection is kept open
+    numConns
+
+withConnectionPool
+  :: BC.ByteString
+  -- ^ Libpq connection string
+  -> Int
+  -- ^ Maximum number of postgresql connections to allow
+  -> (Pool Connection -> IO r)
+  -> IO r
+withConnectionPool connectionInfo numConns f = bracket
+  (mkConnectionPool connectionInfo numConns)
+  destroyAllResources
+  f
+
+withConnectionFromPool :: Pool Connection -> (Connection -> IO b) -> IO b
+withConnectionFromPool pool action = Pool.withResource pool $ action

--- a/metadata-sync/src/Cardano/Metadata/Sync/Config.hs
+++ b/metadata-sync/src/Cardano/Metadata/Sync/Config.hs
@@ -2,19 +2,38 @@
 
 module Cardano.Metadata.Sync.Config where
 
-import Data.Text (Text)
+import Control.Exception
+    ( bracket )
+import qualified Data.ByteString.Char8 as BC
+import Data.Pool
+    ( Pool, createPool, destroyAllResources )
+import qualified Data.Pool as Pool
+import Data.Text
+    ( Text )
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
-import Options.Applicative (Parser, ParserInfo)
-import qualified Options.Applicative as Opt
-import Options.Applicative (strOption, long, metavar, help, showDefault, value, option, auto, info, fullDesc, progDesc, header)
-import Data.Pool (Pool, createPool, destroyAllResources)
-import Database.PostgreSQL.Simple (Connection)
-import Data.Time.Clock (NominalDiffTime)
+import Data.Time.Clock
+    ( NominalDiffTime )
+import Database.PostgreSQL.Simple
+    ( Connection )
 import qualified Database.PostgreSQL.Simple as Sql
-import qualified Data.Pool as Pool
-import qualified Data.ByteString.Char8 as BC
-import Control.Exception (bracket)
+import Options.Applicative
+    ( Parser, ParserInfo )
+import Options.Applicative
+    ( auto
+    , fullDesc
+    , header
+    , help
+    , info
+    , long
+    , metavar
+    , option
+    , progDesc
+    , showDefault
+    , strOption
+    , value
+    )
+import qualified Options.Applicative as Opt
 
 data Opts = Opts
     { optDbName              :: Text

--- a/metadata-sync/src/Main.hs
+++ b/metadata-sync/src/Main.hs
@@ -1,19 +1,29 @@
 module Main where
 
+import Control.Exception
+    ( bracket )
 import Control.Monad.IO.Class
     ( liftIO )
 import qualified Data.ByteString.Char8 as BC
+import Data.Pool
+    ( Pool, createPool, destroyAllResources )
 import qualified Data.Text as T
+import Data.Time.Clock
+    ( NominalDiffTime )
+import Database.PostgreSQL.Simple
+    ( Connection, close, connectPostgreSQL )
 import qualified Network.Wai.Handler.Warp as Warp
 import qualified Options.Applicative as Opt
-import Control.Exception (bracket)
-import Database.PostgreSQL.Simple (Connection, connectPostgreSQL, close)
-import Data.Pool (Pool, createPool, destroyAllResources)
-import Data.Time.Clock (NominalDiffTime)
 
 import qualified Cardano.Metadata.Sync as Sync
 import Cardano.Metadata.Sync.Config
-    ( Opts (..), pgConnectionString, parseOpts, withConnectionPool, withConnectionFromPool, opts)
+    ( Opts (..)
+    , opts
+    , parseOpts
+    , pgConnectionString
+    , withConnectionFromPool
+    , withConnectionPool
+    )
 
 main :: IO ()
 main = do

--- a/metadata-sync/src/Main.hs
+++ b/metadata-sync/src/Main.hs
@@ -1,0 +1,34 @@
+module Main where
+
+import Control.Monad.IO.Class
+    ( liftIO )
+import qualified Data.ByteString.Char8 as BC
+import qualified Data.Text as T
+import qualified Network.Wai.Handler.Warp as Warp
+import qualified Options.Applicative as Opt
+import Control.Exception (bracket)
+import Database.PostgreSQL.Simple (Connection, connectPostgreSQL, close)
+import Data.Pool (Pool, createPool, destroyAllResources)
+import Data.Time.Clock (NominalDiffTime)
+
+import qualified Cardano.Metadata.Sync as Sync
+import Cardano.Metadata.Sync.Config
+    ( Opts (..), pgConnectionString, parseOpts, withConnectionPool, withConnectionFromPool, opts)
+
+main :: IO ()
+main = do
+  options@(Opts { optDbConnections = numDbConns
+                , optDbMetadataTableName = tableName
+                , optGitURL = gitURL
+                , optGitSubFolder = gitSubFolder
+                }) <- Opt.execParser opts
+
+  let pgConnString = pgConnectionString options
+  putStrLn $ "Connecting to database using connection string: " <> BC.unpack pgConnString
+  withConnectionPool pgConnString numDbConns $ \pool -> do
+    withConnectionFromPool pool $ \conn -> do
+      putStrLn $ "Reading registry state from '" <> T.unpack gitURL <> "'."
+      state <- Sync.view gitURL gitSubFolder
+  
+      putStrLn $ "Syncing to table '" <> T.unpack tableName <> "'."
+      Sync.write conn tableName state

--- a/metadata-sync/test/Main.hs
+++ b/metadata-sync/test/Main.hs
@@ -1,0 +1,165 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+
+import Control.Monad.IO.Class
+    ( liftIO )
+import Control.Monad.Logger
+    ( runNoLoggingT )
+import Data.Proxy
+    ( Proxy (Proxy) )
+import Data.Tagged
+    ( Tagged, unTagged )
+import Data.Text
+    ( Text )
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import qualified Data.Aeson as Aeson
+import Data.Word
+    ( Word8 )
+import Data.Pool (Pool, destroyAllResources)
+import Control.Monad (join, void)
+import Test.Tasty
+    ( TestTree
+    , askOption
+    , defaultIngredients
+    , defaultMainWithIngredients
+    , includingOptions
+    , testGroup
+    , withResource
+    )
+import Test.Tasty.Options
+import Hedgehog
+    ( evalIO, forAll, property, (===), MonadGen )
+import qualified Hedgehog as H
+    ( Property )
+import Control.Exception (catch, SomeException)
+import qualified Hedgehog.Gen as Gen
+import qualified Data.HashMap.Strict as HM
+import qualified Hedgehog.Range as Range
+import Test.Tasty
+import Test.Tasty.Hedgehog
+
+import Cardano.Metadata.Store.Types
+import Cardano.Metadata.Types.Common (Subject(..), unPropertyName)
+import Cardano.Metadata.Sync.Config (mkConnectionPool, withConnectionFromPool)
+import Cardano.Metadata.Sync (write)
+import Test.Cardano.Metadata.Generators
+    ( ComplexType )
+import qualified Test.Cardano.Metadata.Generators as Gen
+import Test.Cardano.Metadata.Store
+import Database.PostgreSQL.Simple (query, withTransaction, execute, executeMany, Connection)
+import Database.PostgreSQL.Simple.Types (Only(..), Identifier(..))
+
+newtype DbHost = DbHost { _dbHost :: Text }
+newtype DbName = DbName { _dbName :: Text }
+newtype DbUser = DbUser { _dbUser :: Text }
+newtype DbTableName = DbTableName { _dbTableName :: Text }
+
+instance IsOption DbHost where
+  defaultValue   = DbHost "/run/postgresql"
+  parseValue str = Just $ DbHost (T.pack str)
+  optionName     = pure "db-host"
+  optionHelp     = pure "Postgres server hostname or, for UNIX domain sockets, the socket filename."
+
+instance IsOption DbName where
+  defaultValue   = error $ "'" <> unTagged (optionName :: Tagged DbName String) <> "' is required."
+  parseValue str = Just $ DbName (T.pack str)
+  optionName     = pure "db-name"
+  optionHelp     = pure "Database name within the postgres server."
+
+instance IsOption DbUser where
+  defaultValue   = error $ "'" <> unTagged (optionName :: Tagged DbUser String) <> "' is required."
+  parseValue str = Just $ DbUser (T.pack str)
+  optionName     = pure "db-user"
+  optionHelp     = pure "User with which to authenticate to the postgres server"
+
+instance IsOption DbTableName where
+  defaultValue   = DbTableName "metadata_integration_test"
+  parseValue str = Just $ DbTableName (T.pack str)
+  optionName     = pure "db-table"
+  optionHelp     = pure "Postgres database table to submit test data to."
+
+main :: IO ()
+main =
+    defaultMainWithIngredients
+      ((includingOptions
+          [ Option (Proxy @DbHost)
+          , Option (Proxy @DbName)
+          , Option (Proxy @DbUser)
+          , Option (Proxy @DbTableName)
+          ]
+       )
+       : defaultIngredients
+      )
+      testsWithPosgresConn
+
+testsWithPosgresConn :: TestTree
+testsWithPosgresConn =
+  askOption $ \(DbHost dbHost) ->
+  askOption $ \(DbName dbName) ->
+  askOption $ \(DbUser dbUser) ->
+  askOption $ \(DbTableName dbTableName) ->
+    withResource
+      ( (,dbTableName) <$> mkConnectionPool (TE.encodeUtf8 $ "host=" <> dbHost <> " dbname=" <> dbName <> " user=" <> dbUser) 1 )
+      ( \(pool, _) -> destroyAllResources pool )
+      tests
+
+tests
+  :: IO ( Pool Connection, Text )
+  -> TestTree
+tests resources =
+  testGroup "integration tests"
+    [
+      testGroup "Metadata sync script"
+       [ testProperty "write/last-wins" (prop_write_last_wins resources)
+       , testProperty "write/no-partial-write" (prop_write_no_partial resources)
+       ]
+    ]
+
+prop_write_last_wins :: IO (Pool Connection, Text) -> H.Property
+prop_write_last_wins getPool = property $ do
+  (pool, tableName) <- evalIO getPool
+  kvs1 <- forAll genKvs
+  kvs2 <- forAll genKvs
+
+  join $ evalIO $ withConnectionFromPool pool $ \conn -> do
+    reset conn tableName
+    result <- write conn tableName kvs1 >> write conn tableName kvs2 >> toList conn tableName
+
+    reset conn tableName
+    expected <- write conn tableName kvs2 >> toList conn tableName
+
+    pure $
+      result === expected
+
+prop_write_no_partial :: IO (Pool Connection, Text) -> H.Property
+prop_write_no_partial getPool = property $ do
+  (pool, tableName) <- evalIO getPool
+  kvs <- forAll genKvs
+
+  join $ evalIO $ withConnectionFromPool pool $ \conn -> do
+    reset conn tableName
+    result <- (write conn tableName (kvs <> [undefined]) `catch` (\(_ :: SomeException) -> pure ())) >> toList conn tableName
+
+    pure $
+      result === []
+
+reset :: Connection -> Text -> IO ()
+reset conn table = do
+  void $ execute conn "CREATE TABLE IF NOT EXISTS ? (\"key\" VARCHAR PRIMARY KEY UNIQUE, \"value\" JSONB NOT NULL)" (Only $ Identifier table)
+  void $ execute conn "TRUNCATE ?" (Only $ Identifier table)
+
+toList :: Connection -> Text -> IO [(Subject, Aeson.Value)]
+toList conn table = do
+  results <- query conn "SELECT key, value FROM ?" (Only $ Identifier table)
+
+  pure $ fmap (\(k, v) -> (Subject k, v)) results 
+
+genKvs :: MonadGen m => m [(Subject, Aeson.Value)]
+genKvs =
+  let
+    kv = (,) <$> Gen.subject <*> (fmap (Aeson.Object . HM.fromList) $ Gen.list (Range.linear 0 20) ((,) <$> (unPropertyName <$> Gen.propertyName) <*> Gen.propertyValue))
+  in
+    Gen.list (Range.linear 0 15) kv

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -38,6 +38,7 @@ let
         packages.metadata-lib = filterSubDir "metadata-lib";
         packages.metadata-server = filterSubDir "metadata-server";
         packages.metadata-webhook = filterSubDir "metadata-webhook";
+        packages.metadata-sync = filterSubDir "metadata-sync";
         packages.metadata-store-postgres = filterSubDir "metadata-store-postgres";
         packages.metadata-validator-github = filterSubDir "metadata-validator-github";
       }
@@ -46,12 +47,14 @@ let
         packages.metadata-lib.flags.release = true;
         packages.metadata-server.flags.release = true;
         packages.metadata-webhook.flags.release = true;
+        packages.metadata-sync.flags.release = true;
         packages.metadata-store-postgres.flags.release = true;
         packages.metadata-validator-github.flags.release = true;
       }
       {
         packages.metadata-server.components.exes.metadata-server.postInstall = optparseCompletionPostInstall;
         packages.metadata-webhook.components.exes.metadata-webhook.postInstall = optparseCompletionPostInstall;
+        packages.metadata-sync.components.exes.metadata-sync.postInstall = optparseCompletionPostInstall;
         packages.metadata-validator-github.components.exes.metadata-validator-github.postInstall = optparseCompletionPostInstall;
       }
       # Enable profiling on executables if the profiling argument is set.
@@ -59,6 +62,7 @@ let
         enableLibraryProfiling = true;
         packages.metadata-server.components.exes.metadata-server.enableExecutableProfiling = true;
         packages.metadata-webhook.components.exes.metadata-webhook.enableExecutableProfiling = true;
+        packages.metadata-sync.components.exes.metadata-sync.enableExecutableProfiling = true;
         packages.metadata-validator-github.components.exes.metadata-validator-github.enableExecutableProfiling = true;
       })
 
@@ -106,6 +110,7 @@ let
       }
       {
         packages.metadata-store-postgres.components.tests.integration-tests.doCheck = false;
+        packages.metadata-sync.components.tests.integration-tests.doCheck = false;
       }
     ];
   });

--- a/nix/nixos/metadata-server.nix
+++ b/nix/nixos/metadata-server.nix
@@ -105,6 +105,7 @@ in {
       serviceConfig = {
         ExecStart = config.services.metadata-server.script;
         DynamicUser = true;
+        User = config.services.metadata-server.user;
         RuntimeDirectory = "metadata-server";
         StateDirectory = "metadata-server";
       };

--- a/nix/nixos/metadata-sync.nix
+++ b/nix/nixos/metadata-sync.nix
@@ -111,6 +111,7 @@ in {
       serviceConfig = {
         ExecStart = config.services.metadata-sync.script;
         DynamicUser = true;
+        User = config.services.metadata-sync.user;
         RuntimeDirectory = "metadata-sync";
         StateDirectory = "metadata-sync";
       };

--- a/nix/nixos/metadata-sync.nix
+++ b/nix/nixos/metadata-sync.nix
@@ -1,0 +1,131 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.services.metadata-sync;
+in {
+
+  options = {
+    services.metadata-sync = {
+      enable = lib.mkEnableOption "enable the metadata sync script";
+      script = lib.mkOption {
+        internal = true;
+        type = lib.types.package;
+      };
+      offchainMetadataToolsPkgs = lib.mkOption {
+        type = lib.types.attrs;
+        default = (import ../../. {}).project;
+        defaultText = "offchain-metadata-tools pkgs";
+        description = ''
+          The offchain-metadata-tools package set.
+        '';
+        internal = true;
+      };
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = cfg.offchainMetadataToolsPkgs.metadata-sync.components.exes.metadata-sync;
+      };
+      user = lib.mkOption {
+        type = lib.types.str;
+        # Linux OS user can have a hyphen (`-`) along with systemd service names as standard
+        default = "metadata-sync";
+        description = "the user to run as";
+      };
+      git = {
+        repositoryUrl = lib.mkOption {
+          type = lib.types.str;
+          description = "URL of the git repository of the metadata registry.";
+        };
+
+        metadataFolder = lib.mkOption {
+          type = lib.types.str;
+          default = "/";
+          description = "Folder within the git repository that contains the metadata entries.";
+        };
+      };
+      postgres = {
+        socketdir = lib.mkOption {
+          type = lib.types.str;
+          default = "/run/postgresql";
+          description = "the path to the postgresql socket";
+        };
+        port = lib.mkOption {
+          type = lib.types.int;
+          default = 5432;
+          description = "the postgresql port";
+        };
+        database = lib.mkOption {
+          type = lib.types.str;
+          # Postgresql cannot have a hyphen (`-`)
+          default = "metadata_server";
+          description = "the postgresql database to use";
+        };
+        table = lib.mkOption {
+          type = lib.types.str;
+          default = "metadata";
+          description = "the postgresql database table to use";
+        };
+        user = lib.mkOption {
+          type = lib.types.str;
+          # Postgresql cannot have a hyphen (`-`)
+          default = "metadata_user";
+          description = "the postgresql user to use";
+        };
+        numConnections = lib.mkOption {
+          type = lib.types.int;
+          default = 1;
+          description = "the number of connections to open to the postgresql database";
+        };
+      };
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    services.metadata-sync.script = let
+      exec = "metadata-sync";
+      cmd = builtins.filter (x: x != "") [
+          "${cfg.package}/bin/${exec}"
+          "--db ${config.services.metadata-sync.postgres.database}"
+          "--db-user ${config.services.metadata-sync.postgres.user}"
+          "--db-host ${config.services.metadata-sync.postgres.socketdir}"
+          "--db-table ${config.services.metadata-sync.postgres.table}"
+          "--db-conns ${toString config.services.metadata-sync.postgres.numConnections}"
+          "--git-url ${config.services.metadata-sync.git.repositoryUrl}"
+          "--git-metadata-folder ${config.services.metadata-sync.git.metadataFolder}"
+      ];
+    in pkgs.writeShellScript "metadata-sync" ''
+      set -euo pipefail
+      echo "Starting ${exec}: ${lib.concatStringsSep "\"\n   echo \"" cmd}"
+      echo "..or, once again, in a single line:"
+      echo "${toString cmd}"
+      exec ${toString cmd}
+    '';
+    environment.systemPackages = [ cfg.package config.services.postgresql.package ];
+    systemd.services.metadata-sync = {
+      path = [ cfg.package pkgs.netcat pkgs.postgresql pkgs.git ];
+      preStart = ''
+        for x in {1..60}; do
+          nc -z localhost ${toString config.services.metadata-sync.postgres.port} && break
+          echo loop $x: waiting for postgresql 2 sec...
+          sleep 2
+        done
+        sleep 1
+      '';
+      serviceConfig = {
+        ExecStart = config.services.metadata-sync.script;
+        DynamicUser = true;
+        RuntimeDirectory = "metadata-sync";
+        StateDirectory = "metadata-sync";
+      };
+
+      wantedBy = [ "multi-user.target" ];
+      after = [ "postgres.service" ];
+      requires = [ "postgresql.service" ];
+    };
+
+    systemd.timers.run-metadata-sync = {
+      timerConfig = {
+        Unit = "metadata-sync.service";
+        OnCalendar = "hourly";
+      };
+      wantedBy = [ "timers.target" ];
+    };
+  };
+}

--- a/nix/nixos/metadata-webhook.nix
+++ b/nix/nixos/metadata-webhook.nix
@@ -111,6 +111,7 @@ in {
       serviceConfig = {
         ExecStart = config.services.metadata-webhook.script;
         DynamicUser = true;
+        User = config.services.metadata-webhook.user;
         RuntimeDirectory = "metadata-webhook";
         StateDirectory = "metadata-webhook";
         StandardOutput = "journal";

--- a/nix/nixos/module-list.nix
+++ b/nix/nixos/module-list.nix
@@ -1,4 +1,5 @@
 [
   ./metadata-server.nix
   ./metadata-webhook.nix
+  ./metadata-sync.nix
 ]

--- a/nix/nixos/tests/default.nix
+++ b/nix/nixos/tests/default.nix
@@ -17,6 +17,7 @@ with pkgs.commonLib;
   callTest = fn: args: forAllSystems (system: let test = importTest fn args system; in hydraJob test // { inherit test; });
 in rec {
   metadataStorePostgres = callTest ./metadata-store-postgres.nix { inherit haskellPackages; };
+  metadataSync = callTest ./metadata-sync.nix { inherit haskellPackages; };
   # Test will require local faucet setup
   # asset                 = callTest ./docs/asset.nix { inherit (pkgs.commonLib) sources; };
   noNixSetup            = callTest ./docs/no-nix-setup.nix { inherit haskellPackages; };

--- a/nix/nixos/tests/metadata-sync.nix
+++ b/nix/nixos/tests/metadata-sync.nix
@@ -1,0 +1,93 @@
+
+{ pkgs, haskellPackages, ... }:
+with pkgs;
+let
+  # Single source of truth for all tutorial constants
+  database      = "postgres";
+  table         = "metadata";
+  user          = "metadata-server";
+  postgresUser  = "metadata_server";
+  postgresPort  = 5432;
+in
+{
+  name = "metadata-sync-integration-test";
+
+  nodes = {
+    server = { config, ... }: {
+      nixpkgs.pkgs = pkgs;
+      imports = [
+        ../.
+      ];
+
+      # Open the default port for `postgrest` in the firewall
+      networking.firewall.allowedTCPPorts = [];
+
+      services.postgresql = {
+        enable = true;
+        port = postgresPort;
+        package = pkgs.postgresql;
+        ensureDatabases = [ "${database}" ];
+        ensureUsers = [
+          {
+            name = "${postgresUser}";
+            ensurePermissions = {
+              "DATABASE ${database}" = "ALL PRIVILEGES";
+            };
+          }
+        ];
+        identMap = ''
+          metadata-server-users root ${postgresUser}
+          metadata-server-users ${user} ${postgresUser}
+          metadata-server-users postgres postgres
+        '';
+        authentication = ''
+          local all all ident map=metadata-server-users
+        '';
+      };
+
+      users = {
+        mutableUsers = false;
+
+        users = {
+          # For ease of debugging the VM as the `root` user
+          root.password = "";
+
+          # Create a system user that matches the database user so that we
+          # can use peer authentication.
+          "${user}".isSystemUser = true;
+        };
+      };
+
+      services.metadata-server = {
+        enable = true;
+
+        user = user;
+
+        postgres = {
+          port     = postgresPort;
+          table    = table;
+          user     = postgresUser;
+          database = database;
+        };
+      };
+    };
+  };
+
+  testScript =
+    ''
+    import json
+    import sys
+
+    start_all()
+
+    server.wait_for_open_port(${toString postgresPort})
+
+    server.succeed(
+        "${haskellPackages.metadata-sync.components.tests.integration-tests}/bin/integration-tests \
+        --db-user ${postgresUser} \
+        --db-host /run/postgresql \
+        --db-name ${database} \
+        --db-table ${table}"
+    )
+    '';
+}

--- a/release.nix
+++ b/release.nix
@@ -103,6 +103,7 @@ let
       [
         jobs.native.metadata-server.x86_64-linux
         jobs.native.metadata-webhook.x86_64-linux
+        jobs.native.metadata-sync.x86_64-linux
         jobs.native.metadata-validator-github.x86_64-linux
         jobs.native.token-metadata-creator.x86_64-linux
 


### PR DESCRIPTION
- Adds a script that queries the GH repository and sets the state of
metadata database to match.
- Add NixOS service.
- Add integration tests that check that the write part of the script
writes correctly, and doesn't touch the database at all if an
exception occurs.