### PR TITLE
Update cmd producing encoded asset name

### DIFF
--- a/docs/index.org
+++ b/docs/index.org
@@ -503,7 +503,7 @@ And the base16-encoding of the asset name like so:
 
 #+BEGIN_SRC shell :tangle asset.sh :tangle-mode (identity #o755)
 export ASSET_NAME="quid"
-export ASSET_ENC=$(echo $ASSET_NAME | basenc --base16 | awk '{print tolower($0)}' | sed 's/..$//')
+export ASSET_ENC=$(echo -n $ASSET_NAME | basenc --base16 | awk '{print tolower($0)}')
 echo "Asset name '$ASSET_NAME' encoded as base16: '$ASSET_ENC'"
 #+END_SRC
 

--- a/docs/index.org
+++ b/docs/index.org
@@ -503,7 +503,7 @@ And the base16-encoding of the asset name like so:
 
 #+BEGIN_SRC shell :tangle asset.sh :tangle-mode (identity #o755)
 export ASSET_NAME="quid"
-export ASSET_ENC=$(echo $ASSET_NAME | basenc --base16 | awk '{print tolower($0)}')
+export ASSET_ENC=$(echo $ASSET_NAME | basenc --base16 | awk '{print tolower($0)}' | sed 's/..$//')
 echo "Asset name '$ASSET_NAME' encoded as base16: '$ASSET_ENC'"
 #+END_SRC
 


### PR DESCRIPTION
```
export ASSET_ENC=$(echo $ASSET_NAME | basenc --base16 | awk '{print tolower($0)}')
```

It seems that `basenc --base16` produces a hash that has always additional `0a` characters at the end. As a consequence the whole subject of the metadata will have additional trailing `0a` in the server and therefore it will not be retrieved by cardano-wallet.

For instance assetName = PlutusCoin in wallet is visible as `506c75747573436f696e` whereas produced by the command above it will be `506c75747573436f696e0a`. The fix is to update this command in manual to remove last two characters.